### PR TITLE
hot-fix/dnp3-python-change-classname

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 volttron-lib-base-driver = "^0.2.0rc0"
-dnp3-python = "^0.2.3b2"
+dnp3-python = ">=0.2.3b3, <0.3.0"
 
 [tool.poetry.group.dev.dependencies]
 volttron-testing = "^0.4.0rc0"


### PR DESCRIPTION
Referencing https://github.com/eclipse-volttron/volttron-dnp3-outstation/pull/8

Similar to the aforementioned issue, it affects the master as well.